### PR TITLE
Release 1.2.0 - Multi-select support for session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode-test/
 *.vsix
 .DS_Store
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the "File Sessions" extension will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-10
+
+### Added
+- **Multi-select for Session Files**: Select multiple files inside a saved session using `Shift` or `Ctrl`/`Cmd` and act on them all at once
+  - **Remove File(s) from Session**: Click the ✖️ inline button or right-click → "Remove File(s) from Session" to remove all selected files in one atomic operation
+  - **Open File(s)**: Right-click → "Open File(s)" to open all selected files at once
+  - Right-click context menu on session file items now exposes both "Open File(s)" and "Remove File(s) from Session" actions
+- New `removeFilesFromSession()` batch method in `SessionService` for atomic multi-file removal (single save + single event)
+
 ## [1.1.1] - 2026-02-18
 
 ### Fixed
@@ -66,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No telemetry or data collection
 - Open source with MIT license
 
+[1.2.0]: https://github.com/rodrigocvv/file-sessions/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/rodrigocvv/file-sessions/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/rodrigocvv/file-sessions/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/rodrigocvv/file-sessions/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ code --install-extension rodrigocvv.file-sessions
 - **Rename**: Right-click session → "Rename Session"
 - **Delete**: Right-click session → "Delete Session"
 - **Remove Individual Files**: Expand session → click **✖️** next to a file
+- **Remove Multiple Files**: Hold `Shift` or `Ctrl`/`Cmd` to select files → right-click → "Remove File(s) from Session"
+- **Open Multiple Files**: Hold `Shift` or `Ctrl`/`Cmd` to select files → right-click → "Open File(s)"
 - **View Files**: Click on session name to expand and see all files
 - **Open Single File**: Click on any file in the session to open just that file
 
@@ -383,7 +385,8 @@ Manual sessions you create for different tasks and features.
 - ➕ **Add File** - Add currently open file to session
 - ✏️ **Rename** - Change session name
 - 🗑️ **Delete** - Remove session
-- ✖️ **Remove File** - Remove single file from session
+- ✖️ **Remove File** - Remove single file from session (inline button)
+- 🗂️ **Multi-select** - Hold `Shift`/`Ctrl` to select multiple files, then right-click for "Open File(s)" or "Remove File(s) from Session"
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "file-sessions",
   "displayName": "File Sessions",
   "description": "Save, manage, and restore groups of open files in your workspace",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "publisher": "rodrigocvv",
   "icon": "icon.png",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -96,9 +96,15 @@
       },
       {
         "command": "fileSessions.removeFileFromSession",
-        "title": "Remove File from Session",
+        "title": "Remove File(s) from Session",
         "category": "File Sessions",
         "icon": "$(close)"
+      },
+      {
+        "command": "fileSessions.openSelectedFiles",
+        "title": "Open File(s)",
+        "category": "File Sessions",
+        "icon": "$(go-to-file)"
       },
       {
         "command": "fileSessions.openBranchSession",
@@ -209,6 +215,16 @@
           "group": "inline"
         },
         {
+          "command": "fileSessions.openSelectedFiles",
+          "when": "view == fileSessions.sessionsView && viewItem == sessionFile",
+          "group": "open@1"
+        },
+        {
+          "command": "fileSessions.removeFileFromSession",
+          "when": "view == fileSessions.sessionsView && viewItem == sessionFile",
+          "group": "manage@1"
+        },
+        {
           "command": "fileSessions.openBranchSession",
           "when": "view == fileSessions.branchSessionsView && viewItem == branchSession",
           "group": "inline"
@@ -260,6 +276,10 @@
         },
         {
           "command": "fileSessions.removeFileFromSession",
+          "when": "false"
+        },
+        {
+          "command": "fileSessions.openSelectedFiles",
           "when": "false"
         },
         {

--- a/src/application/sessionService.ts
+++ b/src/application/sessionService.ts
@@ -294,6 +294,47 @@ export class SessionService {
   }
 
   /**
+   * Remove multiple files from a session in one atomic operation
+   */
+  async removeFilesFromSession(sessionId: string, filePaths: string[]): Promise<boolean> {
+    try {
+      const session = this.getSessionById(sessionId);
+      if (!session) {
+        vscodeAdapter.showError('Session not found');
+        return false;
+      }
+
+      const pathSet = new Set(filePaths);
+      const updatedFiles = session.files.filter((f) => !pathSet.has(f.path));
+
+      if (updatedFiles.length === session.files.length) {
+        vscodeAdapter.showError('Files not found in session');
+        return false;
+      }
+
+      const updatedSession = updateSession(session, { files: updatedFiles });
+      const index = this.sessions.findIndex((s) => s.id === sessionId);
+      this.sessions[index] = updatedSession;
+
+      await this.repository.saveSessions(this.sessions);
+      this.events.emit({ type: 'sessionUpdated', session: updatedSession });
+
+      this.logger.appendLine(
+        `Removed ${filePaths.length} file(s) from session "${session.name}"`
+      );
+
+      return true;
+    } catch (error) {
+      const message = `Failed to remove files: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+      this.logger.appendLine(message);
+      vscodeAdapter.showError(message);
+      return false;
+    }
+  }
+
+  /**
    * Remove a file from a session
    */
   async removeFileFromSession(sessionId: string, filePath: string): Promise<boolean> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const treeView = vscode.window.createTreeView('fileSessions.sessionsView', {
       treeDataProvider: treeProvider,
       showCollapseAll: true,
+      canSelectMany: true,
     });
     context.subscriptions.push(treeView);
 

--- a/src/ui/commands.ts
+++ b/src/ui/commands.ts
@@ -39,8 +39,15 @@ export class CommandManager {
     this.registerCommand('fileSessions.addFileToSession', (item: SessionTreeItem) =>
       this.handleAddFileToSession(item)
     );
-    this.registerCommand('fileSessions.removeFileFromSession', (item: FileTreeItem) =>
-      this.handleRemoveFileFromSession(item)
+    this.registerCommand(
+      'fileSessions.removeFileFromSession',
+      (item: FileTreeItem, allSelected: FileTreeItem[]) =>
+        this.handleRemoveFileFromSession(item, allSelected)
+    );
+    this.registerCommand(
+      'fileSessions.openSelectedFiles',
+      (item: FileTreeItem, allSelected: FileTreeItem[]) =>
+        this.handleOpenSelectedFiles(item, allSelected)
     );
 
     // Branch session commands
@@ -253,26 +260,82 @@ export class CommandManager {
   }
 
   /**
-   * Handle remove file from session command
+   * Handle remove file(s) from session command (supports multi-select)
    */
-  private async handleRemoveFileFromSession(item: FileTreeItem): Promise<void> {
+  private async handleRemoveFileFromSession(
+    item: FileTreeItem,
+    allSelected: FileTreeItem[]
+  ): Promise<void> {
     if (!item || !item.file) {
       vscodeAdapter.showError('Invalid file');
       return;
     }
 
     try {
-      const success = await this.sessionService.removeFileFromSession(
-        item.sessionId,
-        item.file.path
-      );
+      const items =
+        allSelected && allSelected.length > 1 ? allSelected : [item];
+
+      // Group by sessionId (all selected items should be from the same session,
+      // but handle gracefully if not)
+      const bySession = new Map<string, string[]>();
+      for (const fileItem of items) {
+        if (!(fileItem instanceof FileTreeItem)) {
+          continue;
+        }
+        const paths = bySession.get(fileItem.sessionId) ?? [];
+        paths.push(fileItem.file.path);
+        bySession.set(fileItem.sessionId, paths);
+      }
+
+      let success = true;
+      for (const [sessionId, paths] of bySession) {
+        const result = await this.sessionService.removeFilesFromSession(sessionId, paths);
+        if (!result) {
+          success = false;
+        }
+      }
 
       if (success) {
-        vscodeAdapter.showInfo('File removed from session');
+        const count = items.length;
+        vscodeAdapter.showInfo(
+          count === 1 ? 'File removed from session' : `${count} files removed from session`
+        );
       }
     } catch (error) {
       vscodeAdapter.showError(
         `Failed to remove file: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  /**
+   * Handle open selected file(s) command (supports multi-select)
+   */
+  private async handleOpenSelectedFiles(
+    item: FileTreeItem,
+    allSelected: FileTreeItem[]
+  ): Promise<void> {
+    if (!item || !item.file) {
+      vscodeAdapter.showError('Invalid file');
+      return;
+    }
+
+    try {
+      const items =
+        allSelected && allSelected.length > 1 ? allSelected : [item];
+
+      for (const fileItem of items) {
+        if (!(fileItem instanceof FileTreeItem)) {
+          continue;
+        }
+        await vscode.commands.executeCommand(
+          'vscode.open',
+          vscode.Uri.file(fileItem.file.path)
+        );
+      }
+    } catch (error) {
+      vscodeAdapter.showError(
+        `Failed to open files: ${error instanceof Error ? error.message : String(error)}`
       );
     }
   }


### PR DESCRIPTION
## Release v1.2.0

### What's new

**Multi-select for Session Files**

Users can now select multiple files inside a saved session using `Shift` or `Ctrl`/`Cmd` and act on all of them at once:

- **Remove File(s) from Session** — inline ✖️ button or right-click menu; removes all selected files in a single atomic operation
- **Open File(s)** — right-click menu; opens all selected files at once

### Changes
- `canSelectMany: true` enabled on the Saved Sessions tree view
- New `removeFilesFromSession()` batch method in `SessionService` (single save + single event)
- `removeFileFromSession` command updated to handle multi-selection via `allSelected` argument
- New `openSelectedFiles` command registered
- Right-click context menu for `sessionFile` items now includes "Open File(s)" and "Remove File(s) from Session"
- README and CHANGELOG updated
